### PR TITLE
Add private-B-change-removes-B-to-A-dep

### DIFF
--- a/patches/private-B-change-removes-B-to-A-dep.patch
+++ b/patches/private-B-change-removes-B-to-A-dep.patch
@@ -1,0 +1,13 @@
+diff --git a/B.java b/B.java
+index b9ad084..3c9e131 100644
+--- a/B.java
++++ b/B.java
+@@ -1,6 +1,7 @@
+ public class B {
+   public static String getPublic() {
+-    return lib.A.getPublic() + "\n" + getPrivate();
++    // return lib.A.getPublic() + "\n" + getPrivate();
++    return getPrivate();
+   }
+ 
+   private static String getPrivate() {


### PR DESCRIPTION
Makes a private change in B that removes the dependency of B on A, this causes and change in the jdeps of B and thus a java compiler classpath change when recompiling C, thus C is recompiled:
```
$ ./script.sh private-B-change-removes-B-to-A-dep
...
INFO: Elapsed time: 0.709s, Critical Path: 0.21s
INFO: 4 processes: 1 internal, 1 darwin-sandbox, 2 worker.
INFO: Build completed successfully, 4 total actions
...
$ cat patches/private-B-change-removes-B-to-A-dep.explain.log
Executing action 'BazelWorkspaceStatusAction stable-status.txt': unconditional execution is requested.
Executing action 'Building libB.jar (1 source file)': One of the files has changed.
Executing action 'Extracting interface for jar bazel-out/darwin_x86_64-fastbuild/bin/libB.jar': One of the files has changed.
Executing action 'Building libC.jar (1 source file)': One of the files has changed.
```
Those are the rebuilds for this scenario:
  * default: recompiles B
  * classpath=bazel: recompiles B/C (C recompiled because compile classpath changed)
  * classpath=bazel + empty jdeps (direct deps only): recompiles B